### PR TITLE
fix: 라벨 영역이 전체 영역을 차지하는 이슈를 개선합니다.

### DIFF
--- a/src/components/@shared/file-upload-with-preview/FileUploadWithPreview.tsx
+++ b/src/components/@shared/file-upload-with-preview/FileUploadWithPreview.tsx
@@ -16,7 +16,7 @@ const FileUploadWithPreviewComponent = ({
 }: FileUploadWithPreviewProps) => {
   return (
     <Box>
-      <FormLabel>
+      <FormLabel width="fit-content">
         <Badge fontSize="md" py="1" px="3">
           {badgeText} <DownloadIcon />
         </Badge>


### PR DESCRIPTION
이슈: 
퀴즈 생성 label 영역이 width가 100%라, 빈 공간을 클릭해도 input이 동작하는 현상을 발견했습니다.

재현 방법:

https://www.kimeru.xyz/create-quiz
썸네일 업로드 옆 빈공간을 클릭한다.

AS-IS

<img width="1435" alt="image" src="https://github.com/kimerukorea/kimeru-client/assets/57122180/d2112548-9373-47b0-8152-4e1bcb48d637">

TO-BE

<img width="1435" alt="image" src="https://github.com/kimerukorea/kimeru-client/assets/57122180/7ffd40d2-49bc-4e9f-b8f6-b94b9f7219cd">

